### PR TITLE
Add coverage settings support

### DIFF
--- a/src/main/java/com/poratu/idea/plugins/tomcat/conf/EnhancedTomcatRunConfiguration.java
+++ b/src/main/java/com/poratu/idea/plugins/tomcat/conf/EnhancedTomcatRunConfiguration.java
@@ -60,6 +60,10 @@ public class EnhancedTomcatRunConfiguration extends TomcatRunConfiguration {
     private boolean updateClassesAndResources = true;
     private boolean updateTriggerFiles = false;
 
+    // Code Coverage Settings
+    private boolean coverageEnabled = false;
+    private boolean trackPerTest = false;
+
     public EnhancedTomcatRunConfiguration(Project project, ConfigurationFactory factory, String name) {
         super(project, factory, name);
         initializeDefaultConfiguration();
@@ -99,6 +103,7 @@ public class EnhancedTomcatRunConfiguration extends TomcatRunConfiguration {
         readEnvironmentConfiguration(element);
         readConnectionConfiguration(element);
         readHotDeploymentConfiguration(element);
+        readCoverageConfiguration(element);
     }
 
     @Override
@@ -111,6 +116,7 @@ public class EnhancedTomcatRunConfiguration extends TomcatRunConfiguration {
         writeEnvironmentConfiguration(element);
         writeConnectionConfiguration(element);
         writeHotDeploymentConfiguration(element);
+        writeCoverageConfiguration(element);
     }
 
     /**
@@ -278,6 +284,27 @@ public class EnhancedTomcatRunConfiguration extends TomcatRunConfiguration {
         element.addContent(hotDeployElement);
     }
 
+    /**
+     * Read code coverage configuration from XML
+     */
+    private void readCoverageConfiguration(@NotNull Element element) {
+        Element coverageElement = element.getChild("coverage");
+        if (coverageElement != null) {
+            coverageEnabled = Boolean.parseBoolean(coverageElement.getAttributeValue("enabled", "false"));
+            trackPerTest = Boolean.parseBoolean(coverageElement.getAttributeValue("perTest", "false"));
+        }
+    }
+
+    /**
+     * Write code coverage configuration to XML
+     */
+    private void writeCoverageConfiguration(@NotNull Element element) {
+        Element coverageElement = new Element("coverage");
+        coverageElement.setAttribute("enabled", String.valueOf(coverageEnabled));
+        coverageElement.setAttribute("perTest", String.valueOf(trackPerTest));
+        element.addContent(coverageElement);
+    }
+
     // Getters and Setters for Phase 2 configuration
 
     // JMX Configuration
@@ -424,6 +451,23 @@ public class EnhancedTomcatRunConfiguration extends TomcatRunConfiguration {
 
     public void setAccessLogPattern(String accessLogPattern) {
         this.accessLogPattern = accessLogPattern;
+    }
+
+    // Code Coverage
+    public boolean isCoverageEnabled() {
+        return coverageEnabled;
+    }
+
+    public void setCoverageEnabled(boolean coverageEnabled) {
+        this.coverageEnabled = coverageEnabled;
+    }
+
+    public boolean isTrackPerTest() {
+        return trackPerTest;
+    }
+
+    public void setTrackPerTest(boolean trackPerTest) {
+        this.trackPerTest = trackPerTest;
     }
 
 

--- a/src/main/java/com/poratu/idea/plugins/tomcat/ui/CodeCoverageTab.java
+++ b/src/main/java/com/poratu/idea/plugins/tomcat/ui/CodeCoverageTab.java
@@ -145,25 +145,23 @@ public class CodeCoverageTab extends JPanel {
     }
 
     public void resetFrom(@NotNull TomcatRunConfiguration configuration) {
-        // For now, code coverage is disabled by default
-        // In the future, these settings could be stored in EnhancedTomcatRunConfiguration
-        enableCoverageCheckBox.setSelected(false);
-        trackPerTestCheckBox.setSelected(false);
+        if (configuration instanceof EnhancedTomcatRunConfiguration) {
+            EnhancedTomcatRunConfiguration enhanced = (EnhancedTomcatRunConfiguration) configuration;
+            enableCoverageCheckBox.setSelected(enhanced.isCoverageEnabled());
+            trackPerTestCheckBox.setSelected(enhanced.isTrackPerTest());
+        } else {
+            enableCoverageCheckBox.setSelected(false);
+            trackPerTestCheckBox.setSelected(false);
+        }
 
         updateCoverageFieldsState();
     }
 
     public void applyTo(@NotNull TomcatRunConfiguration configuration) throws ConfigurationException {
-        // Code coverage settings would be applied to EnhancedTomcatRunConfiguration
-        // For now, this is a placeholder since coverage integration is a future feature
-
         if (configuration instanceof EnhancedTomcatRunConfiguration) {
-            // Future implementation:
-            // EnhancedTomcatRunConfiguration enhancedConfig = (EnhancedTomcatRunConfiguration) configuration;
-            // enhancedConfig.setCoverageEnabled(enableCoverageCheckBox.isSelected());
-            // enhancedConfig.setTrackPerTest(trackPerTestCheckBox.isSelected());
-            // enhancedConfig.setCoverageIncludePatterns(coverageIncludePatternsField.getText());
-            // enhancedConfig.setCoverageExcludePatterns(coverageExcludePatternsField.getText());
+            EnhancedTomcatRunConfiguration enhanced = (EnhancedTomcatRunConfiguration) configuration;
+            enhanced.setCoverageEnabled(enableCoverageCheckBox.isSelected());
+            enhanced.setTrackPerTest(trackPerTestCheckBox.isSelected());
         }
     }
 }

--- a/src/main/java/com/poratu/idea/plugins/tomcat/ui/EnhancedTomcatConfigurationEditor.java
+++ b/src/main/java/com/poratu/idea/plugins/tomcat/ui/EnhancedTomcatConfigurationEditor.java
@@ -250,15 +250,13 @@ public class EnhancedTomcatConfigurationEditor extends SettingsEditor<EnhancedTo
         }
 
         public void resetFrom(@NotNull EnhancedTomcatRunConfiguration configuration) {
-            // Reset code coverage configuration
-            // enableCoverageCheckBox.setSelected(configuration.isCoverageEnabled());
-            // trackPerTestCheckBox.setSelected(configuration.isTrackPerTest());
+            enableCoverageCheckBox.setSelected(configuration.isCoverageEnabled());
+            trackPerTestCheckBox.setSelected(configuration.isTrackPerTest());
         }
 
         public void applyTo(@NotNull EnhancedTomcatRunConfiguration configuration) throws ConfigurationException {
-            // Apply code coverage configuration
-            // configuration.setCoverageEnabled(enableCoverageCheckBox.isSelected());
-            // configuration.setTrackPerTest(trackPerTestCheckBox.isSelected());
+            configuration.setCoverageEnabled(enableCoverageCheckBox.isSelected());
+            configuration.setTrackPerTest(trackPerTestCheckBox.isSelected());
         }
     }
 }


### PR DESCRIPTION
## Summary
- add coverageEnabled and trackPerTest fields to EnhancedTomcatRunConfiguration
- persist coverage options to XML
- read/write coverage settings in CodeCoverageTab UIs

## Testing
- `./gradlew test --no-daemon` *(fails: None of the following functions can be called with the arguments supplied)*

------
https://chatgpt.com/codex/tasks/task_e_68475c52f098832586093ed2e314aa75