### PR TITLE
Allow UI tabs to accept nullable run configuration

### DIFF
--- a/src/main/java/com/poratu/idea/plugins/tomcat/ui/LogsConfigurationTab.java
+++ b/src/main/java/com/poratu/idea/plugins/tomcat/ui/LogsConfigurationTab.java
@@ -13,6 +13,7 @@ import com.intellij.util.ui.JBUI;
 import com.poratu.idea.plugins.tomcat.conf.TomcatRunConfiguration;
 import com.poratu.idea.plugins.tomcat.logging.LogFileConfiguration;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
 import javax.swing.table.AbstractTableModel;
@@ -29,6 +30,7 @@ import java.util.List;
 public class LogsConfigurationTab extends JPanel {
 
     private final Project project;
+    @Nullable
     private final TomcatRunConfiguration configuration;
 
     // UI Components
@@ -41,7 +43,7 @@ public class LogsConfigurationTab extends JPanel {
     // Log file configurations
     private List<LogFileConfiguration> logFileConfigurations;
 
-    public LogsConfigurationTab(@NotNull Project project, @NotNull TomcatRunConfiguration configuration) {
+    public LogsConfigurationTab(@NotNull Project project, @Nullable TomcatRunConfiguration configuration) {
         this.project = project;
         this.configuration = configuration;
         this.logFileConfigurations = new ArrayList<>();

--- a/src/main/java/com/poratu/idea/plugins/tomcat/ui/StartupConnectionTab.java
+++ b/src/main/java/com/poratu/idea/plugins/tomcat/ui/StartupConnectionTab.java
@@ -8,6 +8,7 @@ import com.intellij.ui.table.JBTable;
 import com.intellij.util.ui.JBUI;
 import com.poratu.idea.plugins.tomcat.conf.TomcatRunConfiguration;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
 import javax.swing.table.AbstractTableModel;
@@ -24,6 +25,7 @@ import java.util.Map;
 public class StartupConnectionTab extends JPanel {
 
     private final Project project;
+    @Nullable
     private final TomcatRunConfiguration configuration;
 
     // JMX Configuration
@@ -46,7 +48,7 @@ public class StartupConnectionTab extends JPanel {
     private JCheckBox enableRemoteDebuggingCheckBox;
     private JTextField debugPortField;
 
-    public StartupConnectionTab(@NotNull Project project, @NotNull TomcatRunConfiguration configuration) {
+    public StartupConnectionTab(@NotNull Project project, @Nullable TomcatRunConfiguration configuration) {
         this.project = project;
         this.configuration = configuration;
         this.environmentVariables = new HashMap<>();


### PR DESCRIPTION
## Summary
- allow `LogsConfigurationTab` and `StartupConnectionTab` constructors to accept a nullable `TomcatRunConfiguration`
- mark their internal `configuration` field as `@Nullable`

## Testing
- `./gradlew build` *(fails: None of the following functions can be called with the arguments supplied)*

------
https://chatgpt.com/codex/tasks/task_e_68476081cc3483258ab80e25319bbfdb